### PR TITLE
FIX: Migrate old site setting values to current values

### DIFF
--- a/db/post_migrate/20211011123651_correct_follow_plugin_site_setting_values.rb
+++ b/db/post_migrate/20211011123651_correct_follow_plugin_site_setting_values.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CorrectFollowPluginSiteSettingValues < ActiveRecord::Migration[6.1]
+  def up
+    DB.exec(<<~SQL)
+      UPDATE site_settings
+      SET value = 'no-one'
+      WHERE name IN ('follow_followers_visible', 'follow_following_visible') AND value = 'none'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
The `follow_following_visible` and `follow_followers_visible` site
settings currently have a `no-one` option, but in the past this option
used to be `none` (without the hyphen and one less `o`).
https://github.com/discourse/discourse-follow/commit/13aa4c995ca0cf0ddb5d97f76012ec130334625b
renamed that option to `no-one` but didn't add a migration.

This commit adds the missing migration.