### PR TITLE
FIX: Hide follower status to users with hidden profiles

### DIFF
--- a/app/models/user_follower.rb
+++ b/app/models/user_follower.rb
@@ -43,6 +43,8 @@ class UserFollower < ActiveRecord::Base
       SQL
     end
     relation
+      .joins("LEFT OUTER JOIN user_options uo ON uo.user_id = users.id")
+      .where("uo.user_id IS NULL OR NOT uo.hide_profile_and_presence")
   end
 
   belongs_to :follower_user, class_name: 'User', foreign_key: :follower_id

--- a/lib/follow/notification_handler.rb
+++ b/lib/follow/notification_handler.rb
@@ -13,6 +13,7 @@ class Follow::NotificationHandler
     return if [Post.types[:regular], Post.types[:whisper]].exclude?(post.post_type)
     return if !SiteSetting.follow_notifications_enabled
     return if !post.user.allow_people_to_follow_me
+    return if post.user.user_option&.hide_profile_and_presence
 
     topic = post.topic
     return if !topic || topic.private_message?

--- a/lib/follow/updater.rb
+++ b/lib/follow/updater.rb
@@ -52,6 +52,15 @@ class Follow::Updater
       )
     end
 
+    if @target.user_option&.hide_profile_and_presence
+      raise Discourse::InvalidAccess.new(
+        nil,
+        nil,
+        custom_message: "follow.user_does_not_allow_follow",
+        custom_message_params: { username: @target.username }
+      )
+    end
+
     relation = UserFollower.find_or_initialize_by(
       user_id: @target.id,
       follower_id: @follower.id,

--- a/lib/follow/user_extension.rb
+++ b/lib/follow/user_extension.rb
@@ -4,7 +4,7 @@ module Follow::UserExtension
   def self.prepended(base)
     base.has_many :follower_relations, class_name: 'UserFollower', dependent: :delete_all
     base.has_many :followers, -> (user) {
-      if !user.allow_people_to_follow_me
+      if !user.allow_people_to_follow_me || user.user_option&.hide_profile_and_presence
         where("1=0")
       end
     }, through: :follower_relations, source: :follower_user

--- a/spec/integration/follow_notifications_spec.rb
+++ b/spec/integration/follow_notifications_spec.rb
@@ -428,4 +428,17 @@ describe "Follow plugin notifications" do
       end
     end
   end
+
+  context "when the followed user has hidden profile but has existing followers" do
+    it "the followers no longer receive notification for posts made by the followed user" do
+      expect(followed.followers.count).to be > 0
+      followed.user_option.update!(hide_profile_and_presence: true)
+      create_topic(user: followed).tap do |t|
+        create_post(topic: t, user: followed)
+      end
+      followed.followers.each do |follower|
+        expect(follower.notifications.count).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -185,4 +185,15 @@ describe ::Follow::Updater do
       expect(error.custom_message_params).to eq({ username: user2.username })
     end
   end
+
+  it "does not allow following a user who has hidden their profile" do
+    user2.user_option.update!(hide_profile_and_presence: true)
+    expect do
+      new_updater(user1, user2).watch_follow
+    end.to raise_error do |error|
+      expect(error).to be_a(Discourse::InvalidAccess)
+      expect(error.custom_message).to eq("follow.user_does_not_allow_follow")
+      expect(error.custom_message_params).to eq({ username: user2.username })
+    end
+  end
 end

--- a/spec/models/user_follower_spec.rb
+++ b/spec/models/user_follower_spec.rb
@@ -116,6 +116,14 @@ describe UserFollower do
       expect(posts.pluck(:id)).to contain_exactly(post2.id)
     end
 
+    it "does not include posts from followed users who have hidden their profile" do
+      post1 = Fabricate(:post, user: followed)
+      post2 = Fabricate(:post, user: followed2)
+      followed.user_option.update!(hide_profile_and_presence: true)
+      posts = UserFollower.posts_for(follower, current_user: follower)
+      expect(posts.pluck(:id)).to contain_exactly(post2.id)
+    end
+
     it "does not include small action posts" do
       post1 = Fabricate(:post, user: followed, post_type: Post.types[:small_action])
       post2 = Fabricate(:post, user: followed, post_type: Post.types[:small_action], action_code: "closed.enabled")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,6 +32,12 @@ describe User do
       expect(followed2.followers.pluck(:id)).to contain_exactly(follower1.id, follower2.id)
     end
 
+    it "returns empty relation if the user has hidden their profile" do
+      followed1.user_option.update!(hide_profile_and_presence: true)
+      expect(followed1.followers.pluck(:id)).to be_empty
+      expect(followed2.followers.pluck(:id)).to contain_exactly(follower1.id, follower2.id)
+    end
+
     it "returns empty relation if the default_allow_people_to_follow_me setting " \
     "is false and the user has no explicit preference" do
       SiteSetting.default_allow_people_to_follow_me = false
@@ -57,6 +63,13 @@ describe User do
     it "excludes users who have disabled follows" do
       followed1.custom_fields["allow_people_to_follow_me"] = false
       followed1.save!
+
+      expect(follower1.following.pluck(:id)).to contain_exactly(followed2.id)
+      expect(follower2.following.pluck(:id)).to contain_exactly(followed2.id)
+    end
+
+    it "excludes users who have hidden their profile" do
+      followed1.user_option.update!(hide_profile_and_presence: true)
 
       expect(follower1.following.pluck(:id)).to contain_exactly(followed2.id)
       expect(follower2.following.pluck(:id)).to contain_exactly(followed2.id)


### PR DESCRIPTION
Meta topic: https://meta.discourse.org/t/follow-plugin/110579/307?u=osama.

Currently, if a user you follow hides their profile, you end up in a situation where you can't unfollow them (because they've hidden their profile), still receive notifications for their posts/topics, and their posts show up in your follow feed.

This PR handles this situation by "soft unfollowing" all followers of the user who hides their profile. "Soft" means the follow relationship is not deleted from the database but it's just hidden. I.e., if the user decides to unhide their profile, everyone who used to follow them will follow them again.