### PR TITLE
FIX: Don't include the plugin attributes when serializing more than 1 user objects

### DIFF
--- a/spec/integration/user_cards_route_spec.rb
+++ b/spec/integration/user_cards_route_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe "Attrs added by the plugin to the UserCardSerializer" do
+  fab!(:follower) { Fabricate(:user) }
+  fab!(:followed) { Fabricate(:user) }
+
+  before do
+    Follow::Updater.new(follower, followed).watch_follow
+    sign_in(follower)
+  end
+
+  it "do not break the /user-cards.json route" do
+    get "/user-cards.json", params: { user_ids: [followed.id].join(",") }
+    expect(response.status).to eq(200)
+  end
+end


### PR DESCRIPTION
The `/user-cards.json` route in core serializes multiple `User` objects using the `UserCardSerializer` which means that, in order to avoid N+1 queries, we need to preload all the associations of the `User` model that are needed for the serialization. However, the follow plugin adds a few attributes to the `UserCardSerializer` that depend on associations defined by the plugin, but there is no official API for extending [the set of preloaded associations](https://github.com/discourse/discourse/blob/a560f9d44b6f1c2632e61cab0fa7f17ca7691c88/app/controllers/users_controller.rb#L112-L120) when serializing objects for the `/user-cards.json` route.

This PR adds a temporary hack to exclude the attributes added by the plugin from the `UserCardSerializer` when it's being used for the `/user-cards.json` (but not the single-user user card route `/u/<username>/card.json`. We'll remove this hack once we have an official API for preloading additional associations for the `/user-cards.json` route.

Meta topic: https://meta.discourse.org/t/follow-plugin/110579/315?u=osama.