### PR TITLE
DEV: Fix JS tests and deprecations

### DIFF
--- a/assets/javascripts/discourse/controllers/follow.js
+++ b/assets/javascripts/discourse/controllers/follow.js
@@ -1,6 +1,3 @@
-import { inject as service } from "@ember/service";
 import Controller from "@ember/controller";
 
-export default Controller.extend({
-  router: service(),
-});
+export default Controller.extend({});

--- a/assets/javascripts/discourse/templates/follow.hbs
+++ b/assets/javascripts/discourse/templates/follow.hbs
@@ -1,5 +1,5 @@
-{{#d-section pageClass="user-follow" class="user-secondary-navigation" scrollTop="false"}}
-  {{#mobile-nav class="activity-nav" desktopClass="action-list follow-list nav-stacked" currentPath=router._router.currentPath}}
+{{#d-section pageClass="user-follow" class="user-secondary-navigation" scrollTop=false}}
+  {{#mobile-nav class="activity-nav" desktopClass="action-list follow-list nav-stacked"}}
     {{#if (eq model.id currentUser.id)}}
       <li>
         {{#link-to "feed"}}{{i18n "user.feed.label"}}{{/link-to}}

--- a/test/javascripts/acceptance/follow-posts-feed-test.js
+++ b/test/javascripts/acceptance/follow-posts-feed-test.js
@@ -4,7 +4,7 @@ import {
   query,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import { click } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 


### PR DESCRIPTION
* Passing a boolean attribute as a string is deprecated
* `{{mobile-nav}}` no longer requires a `currentPath` attribute
* we need to import the `visit` helper before we can use it in tests