### PR TITLE
UX: Remove mobile css

### DIFF
--- a/assets/stylesheets/mobile/follow.scss
+++ b/assets/stylesheets/mobile/follow.scss
@@ -1,3 +1,0 @@
-#user-card .first-row .usercard-controls li:not(:nth-child(1)) {
-  border-left: 0.5em solid transparent;
-}


### PR DESCRIPTION
I do not think this line is needed anymore. It seems to be causing issues with other buttons on the mobile card.

### After
<img width="376" alt="image" src="https://user-images.githubusercontent.com/30537603/160130825-b1cc274b-6ccb-47cd-89d3-04301a4a8201.png">


### Before
<img width="364" alt="image" src="https://user-images.githubusercontent.com/30537603/160131007-72f2ed65-3eb7-410a-abe4-61c99fadb5fe.png">