### PR TITLE
FIX: Don't look for removed mobile CSS stylesheet

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -10,7 +10,6 @@
 enabled_site_setting :discourse_follow_enabled
 
 register_asset 'stylesheets/common/follow.scss'
-register_asset 'stylesheets/mobile/follow.scss', :mobile
 
 register_svg_icon "discourse-follow-new-reply"
 register_svg_icon "discourse-follow-new-follower"


### PR DESCRIPTION
Followup to https://github.com/discourse/discourse-follow/commit/3361e4ee63aeaebb9576b3bf744a5bdc7bd9e529. 