### PR TITLE
FIX: Send a single notification

### DIFF
--- a/lib/follow/notification_handler.rb
+++ b/lib/follow/notification_handler.rb
@@ -104,6 +104,8 @@ class Follow::NotificationHandler
         post_number: first_unread_post.post_number,
         data: notification_data.to_json
       )
+      @notified_users << follower
+
       if notification&.id && !follower.suspended?
         PostAlerter.create_notification_alert(
           user: follower,

--- a/plugin.rb
+++ b/plugin.rb
@@ -123,7 +123,6 @@ after_initialize do
   end
 
   on(:post_alerter_before_post) do |post, new_record, notified|
-    notified << User.new(id: 123123123)
     Follow::NotificationHandler.new(post, notified).handle if new_record
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -122,6 +122,12 @@ after_initialize do
     register_editable_user_custom_field(field)
   end
 
+  on(:post_alerter_before_post) do |post, new_record, notified|
+    notified << User.new(id: 123123123)
+    Follow::NotificationHandler.new(post, notified).handle if new_record
+  end
+
+  # TODO(2022-08-30): Remove when post_alerter_before_post is available
   on(:post_alerter_after_save_post) do |post, new_record, notified|
     next if !new_record
     Follow::NotificationHandler.new(post, notified).handle

--- a/spec/integration/follow_notifications_spec.rb
+++ b/spec/integration/follow_notifications_spec.rb
@@ -21,7 +21,7 @@ describe "Follow plugin notifications" do
   fab!(:normal_user) { Fabricate(:user) }
   fab!(:category) { Fabricate(:category) }
 
-  let(:topic) do
+  fab!(:topic) do
     create_topic(category: category).tap do |t|
       create_post(topic: t) # make sure there is a first post
     end
@@ -134,15 +134,12 @@ describe "Follow plugin notifications" do
 
   context "when category notification level is watching" do
     before do
-      # this will create the topic by a non-followed user and then
-      # creates a post by a followed user
-      @notification_post = create_post(topic: topic, user: followed)
-
       CategoryUser.set_notification_level_for_category(
         follower,
         CategoryUser.notification_levels[:watching],
         category.id
       )
+      @notification_post = create_post(topic: topic, user: followed)
     end
 
     it "follower receives only a notification" do
@@ -172,8 +169,8 @@ describe "Follow plugin notifications" do
       )
     end
 
-    it "follower receives 2 notifications" do
-      expect(follower.notifications.size).to eq(2)
+    it "follower receives only a notification" do
+      expect(follower.notifications.count).to eq(1)
     end
 
     it "follower receives mention notification" do
@@ -183,16 +180,6 @@ describe "Follow plugin notifications" do
       )
       expect(notification).to be_present
       expect(notification.post_number).to eq(@notification_post.post_number)
-    end
-
-    it "follower receives a notification for the 1st post in the topic because " \
-    "they watch the category" do
-      notification = follower.notifications.find_by(
-        topic_id: topic.id,
-        notification_type: Notification.types[:posted]
-      )
-      expect(notification).to be_present
-      expect(notification.post_number).to eq(1)
     end
   end
 
@@ -278,7 +265,7 @@ describe "Follow plugin notifications" do
       create_post(user: normal_user, topic: topic)
     end
 
-    it "follower receives 2 notifications" do
+    it "follower receives a notification for followed posters and one for replies" do
       expect(follower.notifications.count).to eq(2)
     end
 


### PR DESCRIPTION
When a user had to be notified of new post, but was also following the
user who posted, they received two notifications. This happened because
there was no way of adding the user to the list of already notified
users.

Needs https://github.com/discourse/discourse/pull/18091.