### PR TITLE
UX: Update plugin's user page navigation to be compatible with new nav

### DIFF
--- a/assets/javascripts/discourse/connectors/user-main-nav/follow-user-container.hbs
+++ b/assets/javascripts/discourse/connectors/user-main-nav/follow-user-container.hbs
@@ -1,3 +1,6 @@
 {{#if model.can_see_network_tab}}
-  {{#link-to "follow"}}{{d-icon "users"}}{{i18n "user.follow_nav"}}{{/link-to}}
+  {{#link-to "follow"}}
+    {{d-icon "users"}}
+    <span>{{i18n "user.follow_nav"}}</span>
+  {{/link-to}}
 {{/if}}

--- a/assets/javascripts/discourse/templates/follow.hbs
+++ b/assets/javascripts/discourse/templates/follow.hbs
@@ -1,22 +1,50 @@
-{{#d-section pageClass="user-follow" class="user-secondary-navigation" scrollTop=false}}
-  {{#mobile-nav class="activity-nav" desktopClass="action-list follow-list nav-stacked"}}
-    {{#if (eq model.id currentUser.id)}}
-      <li>
-        {{#link-to "feed"}}{{i18n "user.feed.label"}}{{/link-to}}
-      </li>
-    {{/if}}
-    {{#if model.can_see_following}}
-      <li>
-        {{#link-to "following"}}{{i18n "user.following.label"}}{{/link-to}}
-      </li>
-    {{/if}}
-    {{#if (and model.can_see_followers model.allow_people_to_follow_me)}}
-      <li>
-        {{#link-to "followers"}}{{i18n "user.followers.label"}}{{/link-to}}
-      </li>
-    {{/if}}
-  {{/mobile-nav}}
-{{/d-section}}
+{{#if this.currentUser.redesigned_user_page_nav_enabled}}
+  <DSection @pageClass="user-follow" />
+
+  <div class="user-navigation user-navigation-secondary">
+    <HorizontalOverflowNav>
+      {{#if (eq model.id currentUser.id)}}
+        <DNavigationItem @route="feed">
+          <span>{{i18n "user.feed.label"}}</span>
+        </DNavigationItem>
+      {{/if}}
+
+      {{#if model.can_see_following}}
+        <DNavigationItem @route="following">
+          <span>{{i18n "user.following.label"}}</span>
+        </DNavigationItem>
+      {{/if}}
+
+      {{#if (and model.can_see_followers model.allow_people_to_follow_me)}}
+        <DNavigationItem @route="followers">
+          <span>{{i18n "user.followers.label"}}</span>
+        </DNavigationItem>
+      {{/if}}
+    </HorizontalOverflowNav>
+  </div>
+{{else}}
+  {{#d-section pageClass="user-follow" class="user-secondary-navigation" scrollTop=false}}
+    {{#mobile-nav class="activity-nav" desktopClass="action-list follow-list nav-stacked"}}
+      {{#if (eq model.id currentUser.id)}}
+        <li>
+          {{#link-to "feed"}}{{i18n "user.feed.label"}}{{/link-to}}
+        </li>
+      {{/if}}
+
+      {{#if model.can_see_following}}
+        <li>
+          {{#link-to "following"}}{{i18n "user.following.label"}}{{/link-to}}
+        </li>
+      {{/if}}
+
+      {{#if (and model.can_see_followers model.allow_people_to_follow_me)}}
+        <li>
+          {{#link-to "followers"}}{{i18n "user.followers.label"}}{{/link-to}}
+        </li>
+      {{/if}}
+    {{/mobile-nav}}
+  {{/d-section}}
+{{/if}}
 
 <section class="user-content user-follows-tab">
   {{outlet}}

--- a/spec/system/follow_user_pages_spec.rb
+++ b/spec/system/follow_user_pages_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe "Follow user pages", type: :system, js: true do
+  fab!(:user1) { Fabricate(:user) }
+  fab!(:user2) { Fabricate(:user) }
+  fab!(:user3) { Fabricate(:user) }
+  fab!(:user2_post) { Fabricate(:post, user: user2) }
+  let(:everyone_group) { Group[:everyone] }
+
+  before do
+    SiteSetting.discourse_follow_enabled = true
+    SiteSetting.follow_followers_visible = FollowPagesVisibility::EVERYONE
+    SiteSetting.follow_following_visible = FollowPagesVisibility::EVERYONE
+
+    Follow::Updater.new(user1, user2).watch_follow
+    Follow::Updater.new(user3, user1).watch_follow
+  end
+
+  describe 'when user has redesigned user page navigation enabled' do
+    before do
+      everyone_group.add(user1)
+      SiteSetting.enable_new_user_profile_nav_groups = everyone_group.name
+      sign_in(user1)
+    end
+
+    it 'should allow user to navigate to the follow user profile pages' do
+      follow_page = PageObjects::Pages::Follow.new(user1)
+      follow_page.visit
+
+      expect(follow_page).to have_following_topic(user2_post.topic)
+
+      follow_page.click_on_followers
+
+      expect(follow_page).to have_follower(user3)
+
+      follow_page.click_on_following
+
+      expect(follow_page).to have_following(user2)
+    end
+  end
+end

--- a/spec/system/page_objects/pages/follow.rb
+++ b/spec/system/page_objects/pages/follow.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class Follow < PageObjects::Pages::Base
+      CONTENT_CLASS = '.user-follows-tab'
+
+      def initialize(user)
+        super()
+        @user = user
+      end
+
+      def visit
+        page.visit("/u/#{@user.username}")
+        click_on I18n.t('js.user.follow_nav')
+        self
+      end
+
+      def click_on_followers
+        click_on I18n.t("js.user.followers.label")
+        self
+      end
+
+      def click_on_following
+        click_on I18n.t("js.user.following.label")
+        self
+      end
+
+      def has_follower?(user)
+        within(CONTENT_CLASS) do
+          page.has_content?(user.username)
+        end
+      end
+      alias_method :has_following?, :has_follower?
+
+      def has_following_topic?(topic)
+        within(CONTENT_CLASS) do
+          page.has_content?(topic.title)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Core has currently introduced a redesigned user page navigation which is
currently considered experimental behind a feature flag. This commit
aims to make the plugin compatible with the redesigned user page
navigation.

## Screenshots

### Desktop 

#### Before

![Screenshot from 2022-11-23 11-27-45](https://user-images.githubusercontent.com/4335742/203464058-65b625ff-14f2-4065-ba8f-d2333ddafb5b.png)

#### After

![Screenshot from 2022-11-23 11-27-30](https://user-images.githubusercontent.com/4335742/203464072-f671f2ab-f203-42e3-9d03-06f517ec8446.png)

### Mobile

#### Before

![Screenshot from 2022-11-23 11-29-00](https://user-images.githubusercontent.com/4335742/203464078-6e7b19cd-4503-4456-9a64-d9095533e813.png) 

#### After

![Screenshot from 2022-11-23 11-29-14](https://user-images.githubusercontent.com/4335742/203464089-9c3af333-0390-4161-ab1b-dbd7b90344c9.png)
