### PR TITLE
DEV: Make follow-post-stream a real component

### DIFF
--- a/assets/javascripts/discourse/components/follow-post-stream.js
+++ b/assets/javascripts/discourse/components/follow-post-stream.js
@@ -1,3 +1,3 @@
 import UserStream from "discourse/components/user-stream";
 
-export default UserStream;
+export default class FollowPostStream extends UserStream {}


### PR DESCRIPTION
Re-exporting the UserStream component as-is leads to unexpected behavior when colocating templates because `FollowPostStream` === `UserStream`. Extending it gives the component its own identity.