### PR TITLE
FIX: Use new plugin API to render notification

### DIFF
--- a/assets/javascripts/discourse/initializers/follow-initializer.js
+++ b/assets/javascripts/discourse/initializers/follow-initializer.js
@@ -1,4 +1,5 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
+import { userPath } from "discourse/lib/url";
 
 export default {
   name: "follow-plugin-initializer",
@@ -20,6 +21,35 @@ export default {
         "notification.following_replied",
         "discourse-follow-new-reply"
       );
+
+      if (api.registerNotificationTypeRenderer) {
+        api.registerNotificationTypeRenderer(
+          "following",
+          (NotificationTypeBase) => {
+            return class extends NotificationTypeBase {
+              get linkTitle() {
+                return I18n.t("notifications.titles.following");
+              }
+
+              get linkHref() {
+                return userPath(this.notification.data.display_username);
+              }
+
+              get icon() {
+                return "discourse-follow-new-follower";
+              }
+
+              get label() {
+                return this.notification.data.display_username;
+              }
+
+              get description() {
+                return I18n.t("notifications.following_description", {});
+              }
+            };
+          }
+        );
+      }
 
       // workaround to make core save custom fields when changing
       // preferences

--- a/test/javascripts/acceptance/follow-notification-test.js
+++ b/test/javascripts/acceptance/follow-notification-test.js
@@ -1,0 +1,52 @@
+import I18n from "I18n";
+import { test } from "qunit";
+import { visit } from "@ember/test-helpers";
+import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("Discourse Follow - notification", function (needs) {
+  needs.user();
+
+  needs.pretender((server, helper) => {
+    server.get("/notifications", () => {
+      return helper.response({
+        notifications: [
+          {
+            id: 25201,
+            user_id: 1,
+            external_id: "1",
+            notification_type: 800,
+            read: false,
+            high_priority: false,
+            slug: null,
+            data: {
+              display_username: "steaky",
+            },
+          },
+        ],
+        total_rows_notifications: 1,
+      });
+    });
+  });
+
+  test("shows follow notification", async (assert) => {
+    await visit("/u/eviltrout/notifications");
+
+    const notification = document.querySelector(".notifications .item");
+    assert.strictEqual(
+      notification.textContent,
+      "steaky has started following you.",
+      "shows the user that has followed you"
+    );
+
+    assert.ok(
+      notification.querySelector("a").href.includes("/u/steaky"),
+      "leads to the user's profile"
+    );
+
+    assert.strictEqual(
+      notification.querySelector("a").title,
+      I18n.t("notifications.titles.following"),
+      "displays the right title"
+    );
+  });
+});


### PR DESCRIPTION
A fix for https://meta.discourse.org/t/no-hyperlink-for-new-follower/271038

Before:
<img width="303" alt="Screenshot 2023-08-29 at 6 09 41 PM" src="https://github.com/discourse/discourse-follow/assets/1555215/b5c290ab-ae9f-4d79-863c-93f80a70ba2d">


After:
<img width="416" alt="Screenshot 2023-08-29 at 6 08 49 PM" src="https://github.com/discourse/discourse-follow/assets/1555215/21273692-73e6-45cd-8c21-80aec048c330">

Comes with a test ✨ 