### PR TITLE
A11Y: remove heading tag from usercard stat

### DIFF
--- a/assets/javascripts/discourse/connectors/user-card-metadata/follow-statistics-user-card.hbs
+++ b/assets/javascripts/discourse/connectors/user-card-metadata/follow-statistics-user-card.hbs
@@ -1,8 +1,12 @@
 {{#if user.total_following}}
-  <span>{{i18n "user.following.label"}}</span>
-  <span class="value">{{user.total_following}}</span>
+  <div class="metadata__following">
+    <span>{{i18n "user.following.label"}}</span>
+    <span class="value">{{user.total_following}}</span>
+  </div>
 {{/if}}
 {{#if user.total_followers}}
-  <span>{{i18n "user.followers.label"}}</span>
-  <span class="value">{{user.total_followers}}</span>
+  <div class="metadata__followers">
+    <span>{{i18n "user.followers.label"}}</span>
+    <span class="value">{{user.total_followers}}</span>
+  </div>
 {{/if}}

--- a/assets/javascripts/discourse/connectors/user-card-metadata/follow-statistics-user-card.hbs
+++ b/assets/javascripts/discourse/connectors/user-card-metadata/follow-statistics-user-card.hbs
@@ -1,10 +1,8 @@
 {{#if user.total_following}}
-  <h3>{{i18n "user.following.label"}}<span
-      class="value"
-    >{{user.total_following}}</span></h3>
+  <span>{{i18n "user.following.label"}}</span>
+  <span class="value">{{user.total_following}}</span>
 {{/if}}
 {{#if user.total_followers}}
-  <h3>{{i18n "user.followers.label"}}<span
-      class="value"
-    >{{user.total_followers}}</span></h3>
+  <span>{{i18n "user.followers.label"}}</span>
+  <span class="value">{{user.total_followers}}</span>
 {{/if}}

--- a/assets/stylesheets/common/follow.scss
+++ b/assets/stylesheets/common/follow.scss
@@ -5,9 +5,9 @@
 }
 
 .follow-statistics-user-card {
-  .value {
-    padding-left: 5px;
-  }
+  // ignores the wrapping div so the contents appear as siblings
+  // along other metadata in the usercard
+  display: contents;
 }
 
 .user-follows-tab .feed-link {


### PR DESCRIPTION
in https://github.com/discourse/discourse/commit/d4ade75583c2c5ef51b09b1d154c305719bc8788 heading tags were removed from the usercard 

this also removes them from the "following" and "followers" stats that the follow plugin adds to the usercard so they're formatted consistently 

The wrapping div generated by the outlet is given `display: contents;` because there are two stats here, and this allows them to appear as siblings to the existing usercard stats rather than having an additional wrapper nesting them and impacting layout. 