### PR TITLE
FIX: Follow button size for mobile

### DIFF
--- a/assets/stylesheets/common/follow.scss
+++ b/assets/stylesheets/common/follow.scss
@@ -14,3 +14,7 @@
   margin-bottom: 1em;
   display: block;
 }
+
+.follow-button-container div {
+  width: 100%;
+}


### PR DESCRIPTION
Makes the Follow/Unfollow Button in user profile 100% width (especially for Mobile experience).

BEFORE / AFTER

<img width="386" alt="button-before" src="https://github.com/user-attachments/assets/7d338eca-b1d5-4a4f-b739-17042b677369">

<img width="386" alt="button-after" src="https://github.com/user-attachments/assets/5db9df74-052b-44de-92ae-f669d7acd8d6">
