### PR TITLE
DEV: update deprecated icon name from user-times to user-xmark

### DIFF
--- a/assets/javascripts/discourse/components/follow-button.js
+++ b/assets/javascripts/discourse/components/follow-button.js
@@ -44,7 +44,7 @@ export default class FollowButton extends Component {
   @discourseComputed("isFollowed", "canFollow")
   icon(isFollowed, canFollow) {
     if (isFollowed && canFollow) {
-      return "user-times";
+      return "user-xmark";
     } else {
       return "user-plus";
     }


### PR DESCRIPTION
This PR updates the deprecated user-times icon name. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.