### PR TITLE
FEATURE: Add following feed to `/filter`

### DIFF
--- a/app/models/user_follower.rb
+++ b/app/models/user_follower.rb
@@ -33,8 +33,8 @@ class UserFollower < ActiveRecord::Base
         .joins("INNER JOIN user_followers ON user_followers.user_id = users.id")
         .preload(:user, :category)
         .where("user_followers.follower_id = ?", user.id)
-        .where("topics.archetype != ?", Archetype.private_message)
-        .where("topics.visible")
+        .listable_topics
+        .visible
         .order(created_at: :desc)
 
     results = filter_opted_out_users(results)

--- a/plugin.rb
+++ b/plugin.rb
@@ -108,4 +108,16 @@ after_initialize do
     next if !new_record
     Follow::NotificationHandler.new(post, notified).handle
   end
+
+  filter_following_topics = ->(scope, username, guardian) do
+    user = User.find_by(username: username)
+
+    next scope if user.nil?
+    next scope.none if user.id != guardian.user.id && !guardian.user.staff?
+
+    topic_ids = UserFollower.posts_for(user, current_user: guardian.user).map { |p| p.topic_id }
+    scope.where("topics.id IN (?)", topic_ids)
+  end
+
+  add_filter_custom_filter("following-feed", &filter_following_topics)
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -115,7 +115,8 @@ after_initialize do
     next scope if user.nil?
     next scope.none if user.id != guardian.user.id && !guardian.user.staff?
 
-    topic_ids = UserFollower.posts_for(user, current_user: guardian.user).map { |p| p.topic_id }
+    topic_ids = UserFollower.topics_for(user, current_user: guardian.user).pluck(:id)
+
     scope.where("topics.id IN (?)", topic_ids)
   end
 

--- a/spec/requests/follow_controller_spec.rb
+++ b/spec/requests/follow_controller_spec.rb
@@ -341,7 +341,7 @@ describe Follow::FollowController do
       get "/filter", params: { q: "following-feed:#{user1.username}", format: :json }
       expect(response.status).to eq(200)
       topic_ids_from_filter = response.parsed_body["topic_list"]["topics"].map { |t| t["id"] }.uniq
-      
+
       expect(topic_ids_from_filter).to match_array(user1_interacted_topics)
     end
   end


### PR DESCRIPTION
Adds `following-feed:<username>` to the `/filter` endpoint

It returns the recent topics from the users that the current user follows (topics from the `/my/follow/feed` page).

Requires https://github.com/discourse/discourse/pull/31908 to be merged
